### PR TITLE
Ambiguous meaning of commandline options -h, -v and -u in README.

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ UINSTALL
 Type 'make uinstall'
 
 USAGE
-Usage: xorc [-hvu] or [text file] [key file]
+Usage: xorc -[hvu] or [text file] [key file]
 Porogram crypts [text file] with [key file] by
 changing it's content to crypted mess.
 To decrypt, crypt file once more with the same key.

--- a/README
+++ b/README
@@ -21,7 +21,7 @@ Type 'make uinstall'
 
 USAGE
 Usage: xorc -[hvu] or [text file] [key file]
-Porogram crypts [text file] with [key file] by
+Program crypts [text file] with [key file] by
 changing it's content to crypted mess.
 To decrypt, crypt file once more with the same key.
 To conclude, if you crypt your file even number of times, the file will be like it was before.
@@ -32,7 +32,7 @@ ARGS
 no args shows -v and -h
 
 ERRORS
-Values returned by program means:
+Values returned by program mean:
 0 - everything's good
 1 - failed to open file
 2 - failed read/write to file


### PR DESCRIPTION
xorc [-hvu] was ambiguous, because this could mean that there is optional option -hvu or that a user could choose - or h or v or u.

Better solution is -[hvu], what means that a user can choose h or v or u, or -(h|v|u), what means that there is an alternative beetween h, v and u.

I also have a question: Does in README (and in Makefile) have to be "uinstall" instead of "uninstall"? Uninstall is correct form for deinstallation.